### PR TITLE
Combine.py generates error in javascript source loader

### DIFF
--- a/lib/jasy/js/output/Combiner.py
+++ b/lib/jasy/js/output/Combiner.py
@@ -152,7 +152,7 @@ def storeSourceLoader(fileName, classes, session, bootCode="", relativeRoot="sou
         files.append('"%s"' % fromWebFolder)
 
     loader = ",".join(files)
-    boot = "function(){%s}" % bootCode if bootCode else ""
+    boot = "function(){%s}" % bootCode if bootCode else "null"
     result = 'core.io.Queue.load([%s], %s, null, true)' % (loader, boot)
 
     writeFile(fileName, result)


### PR DESCRIPTION
If bootCode of storeSourceLoader if empty, the following signature is generated:

core.io.Queue.load(["../../core/src/Assert.js"], , null, true)

This is wrong JS syntax as the second parameter is empty. This patch inserts a null there:

core.io.Queue.load(["../../core/src/Assert.js"], null, null, true)
