### PR TITLE
MetaData doesn't work properly?

### DIFF
--- a/lib/jasy/js/tokenize/Comment.py
+++ b/lib/jasy/js/tokenize/Comment.py
@@ -111,7 +111,13 @@ jsdocFlags = re.compile(r"^@(deprecated|private|public|static)")
 # - @version Version
 jsdocData = re.compile(r"^@(name|namespace|requires|since|version)\s+(\S+)")
 
-
+# Supports:
+# - @name {Name}
+# - @require {Name}
+# - @optional {Name}
+# - @break {Name}
+# - @asset {Path}
+jasyMetaData = re.compile(r"^@(name|require|optional|break|asset)\s+(?:\{(\S+)\})")
 
 # Used to measure the doc indent size (with leading stars in front of content)
 docIndentReg = re.compile(r"^(\s*\*\s*)(\S*)")
@@ -449,6 +455,18 @@ class Comment():
                 self.tags[matched.group(1)] = True
                 continue
             
+            matched = jasyMetaData.match(line)
+            if matched:
+                if self.tags is None:
+                    self.tags = {}
+
+                tagName, tagValue = matched.groups()
+                if tagName == 'name':
+                    self.tags[tagName] = tagValue
+                else:
+                    self.tags.setdefault(tagName, []).append(tagValue)
+                continue
+
             matched = jsdocData.match(line)
             if matched:
                 if self.tags is None:

--- a/test/comments.py
+++ b/test/comments.py
@@ -1241,6 +1241,41 @@ class TestComments(unittest.TestCase):
         self.assertEqual(comment.tags["deprecated"], True)
         self.assertEqual(comment.tags["version"], "1.2")
         self.assertEqual(comment.tags["since"], "0.3")
+
+    def test_doc_tags_jasy_metadata_tags(self):
+
+        parsed = self.process('''
+
+        /**
+         * Comment before metadata
+         *
+         * @asset {app/*}
+         * @asset {lib/*}
+         * @require {core.polyfill.requestAnimationFrame}
+         * @require {Scroller}
+         * @optional {ClassA}
+         * @optional {ClassB}
+         * @break {ClassC}
+         * @break {ClassD}
+         *
+         * Comment after metadata
+         */
+
+        ''')
+
+        self.assertEqual(parsed.type, "script")
+        self.assertEqual(isinstance(parsed.comments, list), True)
+        self.assertEqual(len(parsed.comments), 1)
+
+        comment = parsed.comments[0]
+
+        self.assertEqual(comment.variant, "doc")
+        self.assertEqual(comment.html, "<p>Comment before metadata</p>\n\n<p>Comment after metadata</p>\n")
+        self.assertEqual(type(comment.tags), dict)
+        self.assertEqual(comment.tags["asset"], ["app/*", "lib/*"])
+        self.assertEqual(comment.tags["require"], ["core.polyfill.requestAnimationFrame", "Scroller"])
+        self.assertEqual(comment.tags["optional"], ["ClassA", "ClassB"])
+        self.assertEqual(comment.tags["break"], ["ClassC", "ClassD"])
     
     
     #

--- a/test/metadata.py
+++ b/test/metadata.py
@@ -1,0 +1,97 @@
+import sys, os, unittest
+
+# Extend PYTHONPATH with local 'lib' folder
+jasyroot = os.path.normpath(os.path.join(os.path.abspath(sys.argv[0]), os.pardir, os.pardir, "lib"))
+sys.path.insert(0, jasyroot)
+
+import jasy.js.parse.Parser as Parser
+from jasy.js.MetaData import MetaData
+
+class TestMetaData(unittest.TestCase):
+    def process(self, code):
+        node = Parser.parse(code)
+        metadata = MetaData(node)
+        return metadata
+
+    def test_name(self):
+
+        md = self.process("""
+
+        /**
+          * @name {document.retrieveSelector}
+         */
+
+        document.retrieveSelector = (function (filter) {
+
+	}([].filter));
+
+        """)
+
+        self.assertEqual(md.name, 'document.retrieveSelector')
+
+    def test_require(self):
+
+        md = self.process("""
+
+        /**
+         * @require {core.detect.Platform}
+         */
+	core.Module("core.detect.System", {
+		VALUE: name + " " + version
+	});
+
+        """)
+
+        self.assertEqual(set(md.requires), set(['core.detect.Platform']))
+
+    def test_break(self):
+
+        md = self.process("""
+
+        /**
+         * @break {core.Env}
+         */
+        (function(global, undef)
+        {
+        })(this);
+
+        """)
+
+        self.assertEqual(set(md.breaks), set(['core.Env']))
+
+    def test_asset(self):
+
+        md = self.process("""
+
+        /**
+         * @asset {mynamespace/*}
+         * @asset {externallib/*}
+         */
+        core.Module("mynamespace.App", {
+
+        });
+
+        """)
+
+        self.assertEqual(set(md.assets), set(['mynamespace/*', 'externallib/*']))
+
+    def test_optional(self):
+
+        md = self.process("""
+
+        /**
+         * @optional {optional.a}
+         * @optional {optional.b}
+         */
+        core.Module("mynamespace.App", {
+
+        });
+
+        """)
+
+        self.assertEqual(set(md.optionals), set(['optional.a', 'optional.b']))
+
+
+if __name__ == '__main__':
+    tests = unittest.TestLoader().loadTestsFromTestCase(TestMetaData)
+    unittest.TextTestRunner(verbosity=1).run(tests)


### PR DESCRIPTION
First, if I use `@name {package.ClassName}`,  as documented, MetaData return a value with braces, like the following code.

``` python
import jasy.js.parse.Parser as Parser
from jasy.js.MetaData import MetaData

# JS code is quoted from core.polyfill.RetrieveSelector
node = Parser.parse("""
/**
 * @name {document.retrieveSelector}
 */

document.retrieveSelector = (function (filter) {
  // omit
}([].filter));
""")

metadata = MetaData(node)
print(metadata.name) # result is '{document.retrieveSelector}'
```

I wonder this is a bug or a mistake in the documentation.

Besides, there are other Jasy meta tags like @require, @asset, etc., but the parser seems to do nothing for them. As the result, even if I use `@require someClass` manually to add `someClass` to dependencies, it won't be included into compressed output scripts.
