### PR TITLE
Fix wrong array access in interface check of API generation

### DIFF
--- a/jasy/js/api/Writer.py
+++ b/jasy/js/api/Writer.py
@@ -240,8 +240,8 @@ def connectInterface(className, interfaceName, classApi, interfaceApi):
                 if not "summary" in classEntry and "summary" in interfaceEntry:
                     classEntry["summary"] = interfaceEntry["summary"]
 
-                if "errornous" in classEntry[name] and not "errornous" in interfaceEntry[name]:
-                    del classEntry[name]["errornous"]
+                if "errornous" in classEntry and not "errornous" in interfaceEntry:
+                    del classEntry["errornous"]
 
                 # Priorize return value from interface (it's part of the interface feature set to enforce this)
                 if "returns" in interfaceEntry:


### PR DESCRIPTION
Each interface and class member is checked in a for loop for it's
errorunous state. This seems to be accessed in the wrong way as the
code tries to access members[name][name]. This patch fixes the access
to members[name].
