### PR TITLE
Fix issues with the caching of highlighted doc comments

### DIFF
--- a/jasy/js/api/Comment.py
+++ b/jasy/js/api/Comment.py
@@ -78,6 +78,9 @@ class Comment():
     # Text of the comment converted to HTML (only for doc comment)
     __html = None
     
+    # Text of the comment converted to HTML including highlighting (only for doc comment)
+    __highlightedHTML = None
+
     
     def __init__(self, text, context=None, lineNo=0, indent="", fileId=None):
         # Store context (relation to code)
@@ -136,14 +139,16 @@ class Comment():
 
     def getHtml(self, highlight=True):
         """Returns the comment text converted to HTML"""
+
+        field = "__highlightedHTML" if highlight else "__html"
         
-        if self.variant == "doc" and self.__html is None:
+        if self.variant == "doc" and getattr(self, field, None) is None:
             if markdown is None:
                 raise JasyError("Markdown is not supported by the system. Documentation comments could not be processed into HTML.")
             
-            self.__html = markdown(self.__originalText, highlight)
+            setattr(self, field, markdown(self.__originalText, highlight))
     
-        return self.__html
+        return getattr(self, field, None)
     
     
     def hasHtmlContent(self):

--- a/jasy/js/api/Writer.py
+++ b/jasy/js/api/Writer.py
@@ -326,7 +326,7 @@ class ApiWriter():
         #
         
         header("Processing API Data...")
-        data, index, search = self.process(apiData, classFilter=classFilter, internals=showInternals, privates=showPrivates, printErrors=printErrors)
+        data, index, search = self.process(apiData, classFilter=classFilter, internals=showInternals, privates=showPrivates, printErrors=printErrors, highlightCode=highlightCode)
         
         
         
@@ -358,13 +358,14 @@ class ApiWriter():
                 error("Could not write API data of: %s: %s", className, writeError)
                 continue
 
-        info("Saving highlighted code (%s files)...", len(highlightedCode))
-        for className in highlightedCode:
-            try:
-                writeFile(os.path.join(distFolder, "%s.html" % className), highlightedCode[className])
-            except TypeError as writeError:
-                error("Could not write highlighted code of: %s: %s", className, writeError)
-                continue
+        if highlightCode:
+            info("Saving highlighted code (%s files)...", len(highlightedCode))
+            for className in highlightedCode:
+                try:
+                    writeFile(os.path.join(distFolder, "%s.html" % className), highlightedCode[className])
+                except TypeError as writeError:
+                    error("Could not write highlighted code of: %s: %s", className, writeError)
+                    continue
 
         info("Writing index...")
         writeFile(os.path.join(distFolder, "meta-index.%s" % extension), encode(index, "meta-index"))
@@ -372,7 +373,7 @@ class ApiWriter():
         
 
 
-    def process(self, apiData, classFilter=None, internals=False, privates=False, printErrors=True):
+    def process(self, apiData, classFilter=None, internals=False, privates=False, printErrors=True, highlightCode=True):
         
         knownClasses = set(list(apiData))
 
@@ -640,7 +641,7 @@ class ApiWriter():
                     destApi.main["from"].append(className)
                 
                 else:
-                    destApi = apiData[destName] = ApiData(destName)
+                    destApi = apiData[destName] = ApiData(destName, highlight=highlightCode)
                     destApi.main = {
                         "type" : "Extend",
                         "name" : destName,
@@ -865,7 +866,7 @@ class ApiWriter():
             for split in splits[1:]:
                 if not packageName in apiData:
                     warn("Missing package documentation %s", packageName)
-                    apiData[packageName] = ApiData(packageName)
+                    apiData[packageName] = ApiData(packageName, highlight=highlightCode)
                     apiData[packageName].main = {
                         "type" : "Package",
                         "name" : packageName


### PR DESCRIPTION
Doc comments only stored the first version of the generated HTML associated with them. This resulted in the problem that one could not generate both a highlighted and a not highlighted version of the API data in the same run. This commit fixes it by introducing an addtional field for highlighted HTML doc comments
