### PR TITLE
Fix library loading

### DIFF
--- a/jasy/core/Project.py
+++ b/jasy/core/Project.py
@@ -11,7 +11,7 @@ from jasy.core.Error import JasyError
 from jasy.core.Util import getKey
 from jasy.core.Logging import *
 from jasy.env.Config import Config
-from jasy.env.State import setPermutation, header, loadLibrary
+from jasy.env.State import setPermutation, header
 
 # Item types
 from jasy.item.Item import Item
@@ -195,12 +195,6 @@ class Project():
             content = getattr(self, section, None)
             if content:
                 summary.append("%s %s" % (len(content), section))
-
-        # Import library methods
-        libraryPath = os.path.join(self.__path, "jasylibrary.py")
-        if os.path.exists(libraryPath):
-            methodNumber = loadLibrary(self.__name, libraryPath)
-            summary.append("%s methods" % methodNumber)
 
         # Print out
         if summary:

--- a/jasy/env/Session.py
+++ b/jasy/env/Session.py
@@ -116,9 +116,9 @@ class Session():
             self.__projects.append(project)
 
             # Import library methods
-            libraryPath = os.path.join(self.__path, "jasylibrary.py")
+            libraryPath = os.path.join(project.getPath(), "jasylibrary.py")
             if os.path.exists(libraryPath):
-                loadLibrary(self.__name, libraryPath)
+                loadLibrary(project.getName(), libraryPath)
 
             # Import project defined fields which might be configured using "activateField()"
             fields = project.getFields()

--- a/jasy/env/Session.py
+++ b/jasy/env/Session.py
@@ -118,8 +118,7 @@ class Session():
             # Import library methods
             libraryPath = os.path.join(self.__path, "jasylibrary.py")
             if os.path.exists(libraryPath):
-                methodNumber = loadLibrary(self.__name, libraryPath)
-                summary.append("%s methods" % methodNumber)
+                loadLibrary(self.__name, libraryPath)
 
             # Import project defined fields which might be configured using "activateField()"
             fields = project.getFields()

--- a/jasy/env/Session.py
+++ b/jasy/env/Session.py
@@ -15,7 +15,7 @@ from jasy.core.Permutation import Permutation
 from jasy.core.Config import findConfig
 
 from jasy.core.Error import JasyError
-from jasy.env.State import getPermutation, setPermutation, setTranslation, header
+from jasy.env.State import getPermutation, setPermutation, setTranslation, header, loadLibrary
 from jasy.core.Json import toJson
 from jasy.core.Logging import *
 
@@ -114,6 +114,12 @@ class Session():
             
             # Append to session list
             self.__projects.append(project)
+
+            # Import library methods
+            libraryPath = os.path.join(self.__path, "jasylibrary.py")
+            if os.path.exists(libraryPath):
+                methodNumber = loadLibrary(self.__name, libraryPath)
+                summary.append("%s methods" % methodNumber)
 
             # Import project defined fields which might be configured using "activateField()"
             fields = project.getFields()


### PR DESCRIPTION
Loading of libraries is postponed in newer jasy version because
project loading itself is postponed. This leads to problems in
using library functions without using project functions like
translation loading, asset loading or others.

This fix reintegrates loading of libraries at first dependency
detection and loading step so lib functions can be used everywhere
in tasks.
