### PR TITLE
Wrong file encoding on serving static files in cherrypy

### DIFF
--- a/jasy/http/Server.py
+++ b/jasy/http/Server.py
@@ -3,7 +3,7 @@
 # Copyright 2010-2012 Zynga Inc.
 #
 
-import os, logging, base64, json, requests, cherrypy
+import os, logging, base64, json, requests, cherrypy, locale
 from collections import namedtuple
 
 import jasy.core.Cache as Cache
@@ -216,7 +216,7 @@ class Static(object):
             if extension:
                 extension = extension.lower()[1:]
                 if extension in self.mimeTypes:
-                    contentType = self.mimeTypes[extension]
+                    contentType = self.mimeTypes[extension] + "; charset=" + locale.getpreferredencoding()
 
             return cherrypy.lib.static.serve_file(os.path.abspath(path), content_type=contentType)
             


### PR DESCRIPTION
Static files are read by cherrypy's lib.static.serve_file with system dependent standard encoding.
In python3 documentation of open() the method locale.getpreferredencoding() returns the system's
default encoding, so this is send as additional content type in http header.
