### PR TITLE
Fix error in BlockReducer if doing imediately a return in an 'else if part of an if expression

### DIFF
--- a/jasy/js/optimize/BlockReducer.py
+++ b/jasy/js/optimize/BlockReducer.py
@@ -169,6 +169,12 @@ def __optimize(node, compressor):
         # Optimize using hook operator
         if elsePart and thenPart.type == "return" and elsePart.type == "return":
             # Combine return statement
+            if not hasattr(thenPart, "value"):
+                thenPart.value = Node.Node(None, "identifier")
+                thenPart.value.value = "undefined"
+            if not hasattr(elsePart, "value"):
+                elsePart.value = Node.Node(None, "identifier")
+                elsePart.value.value = "undefined"
             replacement = createReturn(createHook(condition, thenPart.value, elsePart.value))
             node.parent.replace(node, replacement)
             return

--- a/jasy/test/js/blockreduce.py
+++ b/jasy/test/js/blockreduce.py
@@ -524,6 +524,22 @@ class Tests(unittest.TestCase):
             'function foo(){"use strict";doSomething()}foo();'
         )
 
+    def test_return_in_elseif(self):
+        self.assertEqual(self.process(
+            '''
+            var a = function() {
+                if (yyy) {
+                    return;
+                } else if (zzz) {
+                    return;
+                } else {
+                    return;
+                }
+            };
+            '''),
+            'var a=function(){if(yyy)return;if(zzz){return}return};'
+        )
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Test case:

var a = function() {
                if (yyy) {
                    return;
                } else if (zzz) {
                    return;
                } else {
                    return;
                }
            };

This crashes in 0.8.1
