### PR TITLE
Fix #116: Named group error with 100 assets defined

### DIFF
--- a/jasy/asset/Manager.py
+++ b/jasy/asset/Manager.py
@@ -350,7 +350,7 @@ class AssetManager:
             hints.update(classObj.getMetaData(self.__session.getCurrentPermutation()).assets)
         
         # Compile filter expressions
-        matcher = "^%s$" % "|".join(["(%s)" % fnmatch.translate(hint) for hint in hints])
+        matcher = "^%s$" % "|".join(["(?:%s)" % fnmatch.translate(hint) for hint in hints])
         Console.debug("Compiled asset matcher: %s" % matcher)
         
         return re.compile(matcher)


### PR DESCRIPTION
The pattern matching of assets matched every file added with #asset
to an named group. This is very memory consumting and not neccessary
to simply match filenames without accessing defined matched pattern
groups.

Simply changing named groups to anonymous groups fixes this error.
